### PR TITLE
Improved support for custom queries and types

### DIFF
--- a/src/Dapper.DDD.Repository.DependencyInjection/Dapper.DDD.Repository.DependencyInjection.csproj
+++ b/src/Dapper.DDD.Repository.DependencyInjection/Dapper.DDD.Repository.DependencyInjection.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <AdditionalFiles Include="..\..\..\gidas\.sonarlint\gidas\CSharp\SonarLint.xml" Link="SonarLint.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Dapper.DDD.Repository\Dapper.DDD.Repository.csproj" />
   </ItemGroup>
 
@@ -18,10 +22,11 @@
     <PackageProjectUrl>https://github.com/steffenskov/Dapper.DDD.Repository</PackageProjectUrl>
     <PackageTags>Dapper, DDD, Repository, ValueObject</PackageTags>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
+	  <CodeAnalysisRuleSet>..\..\..\gidas\.sonarlint\gidascsharp.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
 	<ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapper.DDD.Repository.DependencyInjection/Dapper.DDD.Repository.DependencyInjection.csproj
+++ b/src/Dapper.DDD.Repository.DependencyInjection/Dapper.DDD.Repository.DependencyInjection.csproj
@@ -1,10 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\..\gidas\.sonarlint\gidas\CSharp\SonarLint.xml" Link="SonarLint.xml" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Dapper.DDD.Repository\Dapper.DDD.Repository.csproj" />
   </ItemGroup>
 
@@ -21,8 +17,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/steffenskov/Dapper.DDD.Repository</PackageProjectUrl>
     <PackageTags>Dapper, DDD, Repository, ValueObject</PackageTags>
-	  <PackageReadmeFile>README.md</PackageReadmeFile>
-	  <CodeAnalysisRuleSet>..\..\..\gidas\.sonarlint\gidascsharp.ruleset</CodeAnalysisRuleSet>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/Dapper.DDD.Repository.MySql/Dapper.DDD.Repository.MySql.csproj
+++ b/src/Dapper.DDD.Repository.MySql/Dapper.DDD.Repository.MySql.csproj
@@ -8,7 +8,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>1.1.3</Version>
+    <Version>1.3.0</Version>
     <Authors>Steffen Skov</Authors>
     <Company>Steffen Skov</Company>
     <Description>MySql and MariaDB support for the Dapper.DDD.Repository package.</Description>

--- a/src/Dapper.DDD.Repository.MySql/MySqlQueryGenerator.cs
+++ b/src/Dapper.DDD.Repository.MySql/MySqlQueryGenerator.cs
@@ -50,13 +50,13 @@ internal class MySqlQueryGenerator<TAggregate> : IQueryGenerator<TAggregate>
 	{
 		var whereClause = GenerateWhereClause();
 
-		var outputProperties = GeneratePropertyList(_entityName, _properties);
+		var outputProperties = GeneratePropertyList(_entityName);
 		return $@"SELECT {outputProperties} FROM {_entityName} WHERE {whereClause};DELETE FROM {_entityName} WHERE {whereClause};";
 	}
 
 	public string GenerateGetAllQuery()
 	{
-		var propertyList = GeneratePropertyList(_entityName, _properties);
+		var propertyList = GeneratePropertyList(_entityName);
 		return $"SELECT {propertyList} FROM {_entityName};";
 	}
 
@@ -64,7 +64,7 @@ internal class MySqlQueryGenerator<TAggregate> : IQueryGenerator<TAggregate>
 	{
 		var whereClause = GenerateWhereClause();
 
-		var propertyList = GeneratePropertyList(_entityName, _properties);
+		var propertyList = GeneratePropertyList(_entityName);
 
 		return $"SELECT {propertyList} FROM {_entityName} WHERE {whereClause};";
 	}
@@ -86,7 +86,7 @@ internal class MySqlQueryGenerator<TAggregate> : IQueryGenerator<TAggregate>
 				throw new InvalidOperationException("Cannot generate INSERT query for table with multiple identity properties");
 			}
 			var property = identityProperties.First();
-			var propertyList = GeneratePropertyList(_entityName, _properties);
+			var propertyList = GeneratePropertyList(_entityName);
 			selectStatement = $"SELECT {propertyList} FROM {_entityName} WHERE {_entityName}.{property.Name} = LAST_INSERT_ID();";
 		}
 		else
@@ -106,7 +106,6 @@ internal class MySqlQueryGenerator<TAggregate> : IQueryGenerator<TAggregate>
 			throw new InvalidOperationException($"GenerateGetQuery for aggregate of type {typeof(TAggregate).FullName} failed as the type has no properties with a setter.");
 		}
 
-		GeneratePropertyList("inserted", _properties);
 		var selectStatement = GenerateGetQuery();
 		return $@"UPDATE {_entityName} SET {setClause} WHERE {GenerateWhereClause()};{selectStatement}";
 	}
@@ -128,9 +127,9 @@ internal class MySqlQueryGenerator<TAggregate> : IQueryGenerator<TAggregate>
 		return string.Join(" AND ", primaryKeys.Select(property => $"{_entityName}.{property.Name} = @{property.Name}"));
 	}
 
-	private string GeneratePropertyList(string tableName, IEnumerable<ExtendedPropertyInfo> propertiess)
+	public string GeneratePropertyList(string tableName)
 	{
-		return string.Join(", ", propertiess.Select(property => GeneratePropertyClause(tableName, property)));
+		return string.Join(", ", _properties.Select(property => GeneratePropertyClause(tableName, property)));
 	}
 
 	private static string GeneratePropertyClause(string tableName, ExtendedPropertyInfo property)

--- a/src/Dapper.DDD.Repository.Sql/Dapper.DDD.Repository.Sql.csproj
+++ b/src/Dapper.DDD.Repository.Sql/Dapper.DDD.Repository.Sql.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>Steffen Skov</Authors>
     <Company>Steffen Skov</Company>
     <Description>MS SqlServer support for the Dapper.DDD.Repository package.</Description>

--- a/src/Dapper.DDD.Repository.Sql/Dapper.DDD.Repository.Sql.csproj
+++ b/src/Dapper.DDD.Repository.Sql/Dapper.DDD.Repository.Sql.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<ItemGroup>
-	  <AdditionalFiles Include="..\..\..\gidas\.sonarlint\gidas\CSharp\SonarLint.xml" Link="SonarLint.xml" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\Dapper.DDD.Repository\Dapper.DDD.Repository.csproj" />
-	</ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dapper.DDD.Repository\Dapper.DDD.Repository.csproj" />
+  </ItemGroup>
 
  <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -19,8 +17,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/steffenskov/Dapper.DDD.Repository</PackageProjectUrl>
     <PackageTags>SqlServer, Dapper, DDD, Repository, ValueObject</PackageTags>
-	  <PackageReadmeFile>README.md</PackageReadmeFile>
-	  <CodeAnalysisRuleSet>..\..\..\gidas\.sonarlint\gidascsharp.ruleset</CodeAnalysisRuleSet>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
 	<ItemGroup>

--- a/src/Dapper.DDD.Repository.Sql/Dapper.DDD.Repository.Sql.csproj
+++ b/src/Dapper.DDD.Repository.Sql/Dapper.DDD.Repository.Sql.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
+	  <AdditionalFiles Include="..\..\..\gidas\.sonarlint\gidas\CSharp\SonarLint.xml" Link="SonarLint.xml" />
+	</ItemGroup>
+	<ItemGroup>
 		<ProjectReference Include="..\Dapper.DDD.Repository\Dapper.DDD.Repository.csproj" />
 	</ItemGroup>
 
@@ -17,10 +20,11 @@
     <PackageProjectUrl>https://github.com/steffenskov/Dapper.DDD.Repository</PackageProjectUrl>
     <PackageTags>SqlServer, Dapper, DDD, Repository, ValueObject</PackageTags>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
+	  <CodeAnalysisRuleSet>..\..\..\gidas\.sonarlint\gidascsharp.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
 	<ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Dapper.DDD.Repository/Dapper.DDD.Repository.csproj
+++ b/src/Dapper.DDD.Repository/Dapper.DDD.Repository.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <Version>1.2.1</Version>
+    <Version>1.3.0</Version>
     <Authors>Steffen Skov</Authors>
     <Company>Steffen Skov</Company>
     <Description>Domain-Driven-Design based repository pattern for Dapper.</Description>

--- a/src/Dapper.DDD.Repository/Dapper.DDD.Repository.csproj
+++ b/src/Dapper.DDD.Repository/Dapper.DDD.Repository.csproj
@@ -13,15 +13,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/steffenskov/Dapper.DDD.Repository</PackageProjectUrl>
     <PackageTags>Dapper, DDD, Repository, ValueObject</PackageTags>
-	  <PackageReadmeFile>README.md</PackageReadmeFile>
-	  <CodeAnalysisRuleSet>..\..\..\gidas\.sonarlint\gidascsharp.ruleset</CodeAnalysisRuleSet>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="..\..\..\gidas\.sonarlint\gidas\CSharp\SonarLint.xml" Link="SonarLint.xml" />
-  </ItemGroup>
-
-	<ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/src/Dapper.DDD.Repository/Dapper.DDD.Repository.csproj
+++ b/src/Dapper.DDD.Repository/Dapper.DDD.Repository.csproj
@@ -14,10 +14,15 @@
     <PackageProjectUrl>https://github.com/steffenskov/Dapper.DDD.Repository</PackageProjectUrl>
     <PackageTags>Dapper, DDD, Repository, ValueObject</PackageTags>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
+	  <CodeAnalysisRuleSet>..\..\..\gidas\.sonarlint\gidascsharp.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\..\gidas\.sonarlint\gidas\CSharp\SonarLint.xml" Link="SonarLint.xml" />
+  </ItemGroup>
+
 	<ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="\"/>
+    <None Include="../../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Dapper.DDD.Repository/Interfaces/IQueryGenerator.cs
+++ b/src/Dapper.DDD.Repository/Interfaces/IQueryGenerator.cs
@@ -1,6 +1,6 @@
-namespace Dapper.DDD.Repository.Interfaces;
+﻿namespace Dapper.DDD.Repository.Interfaces;
 
-public interface IQueryGenerator<TAggregate>
+public interface IQueryGenerator<in TAggregate>
 
 {
 	string GenerateDeleteQuery();
@@ -12,4 +12,6 @@ public interface IQueryGenerator<TAggregate>
 	string GenerateGetQuery();
 
 	string GenerateUpdateQuery(TAggregate aggregate);
+
+	string GeneratePropertyList(string tableName);
 }

--- a/src/Dapper.DDD.Repository/Reflection/TypeConverter.cs
+++ b/src/Dapper.DDD.Repository/Reflection/TypeConverter.cs
@@ -14,7 +14,18 @@ internal class TypeConverter<TComplexType, TSimpleType> : ITypeConverter
 	private readonly Func<TComplexType, TSimpleType> _convertToSimple;
 	private readonly Func<TSimpleType, TComplexType> _convertToComplex;
 
-	public Type SimpleType => typeof(TSimpleType);
+	public Type SimpleType
+	{
+		get
+		{
+			var simpleType = typeof(TSimpleType);
+			if (simpleType.IsValueType) // Wrap in nullable to support nulls
+			{
+				simpleType = typeof(Nullable<>).MakeGenericType(simpleType);
+			}
+			return simpleType;
+		}
+	}
 
 	public TypeConverter(Func<TComplexType, TSimpleType> convertToSimple, Func<TSimpleType, TComplexType> convertToComplex)
 	{

--- a/src/Dapper.DDD.Repository/Repositories/BaseRepository.cs
+++ b/src/Dapper.DDD.Repository/Repositories/BaseRepository.cs
@@ -164,7 +164,13 @@ where TAggregate : notnull
 	{
 		using var connection = _connectionFactory.CreateConnection();
 
-		if (_objectFlattener.ShouldFlattenType<TResult>())
+		if (_objectFlattener.TryGetTypeConverter(typeof(TResult), out var converter))
+		{
+			var simpleType = converter!.SimpleType;
+			var result = await _dapperInjection.QueryAsync(connection, simpleType, query, _objectFlattener.Flatten(param), transaction, commandTimeout, commandType, cancellationToken);
+			return result.Select(simple => (TResult)converter.ConvertToComplex(simple));
+		}
+		else if (_objectFlattener.ShouldFlattenType<TResult>())
 		{
 			var flatType = _objectFlattener.GetFlattenedType<TResult>();
 			var result = await _dapperInjection.QueryAsync(connection, flatType, query, _objectFlattener.Flatten(param), transaction, commandTimeout, commandType, cancellationToken);
@@ -181,7 +187,13 @@ where TAggregate : notnull
 	where TResult : notnull
 	{
 		using var connection = _connectionFactory.CreateConnection();
-		if (_objectFlattener.ShouldFlattenType<TResult>())
+		if (_objectFlattener.TryGetTypeConverter(typeof(TResult), out var converter))
+		{
+			var simpleType = converter!.SimpleType;
+			var result = await _dapperInjection.QuerySingleOrDefaultAsync(connection, simpleType, query, _objectFlattener.Flatten(param), transaction, commandTimeout, commandType, cancellationToken);
+			return result is not null ? (TResult)converter.ConvertToComplex(result) : default;
+		}
+		else if (_objectFlattener.ShouldFlattenType<TResult>())
 		{
 			var flatType = _objectFlattener.GetFlattenedType<TResult>();
 			var result = await _dapperInjection.QuerySingleOrDefaultAsync(connection, flatType, query, _objectFlattener.Flatten(param), transaction, commandTimeout, commandType, cancellationToken);
@@ -199,7 +211,13 @@ where TAggregate : notnull
 	{
 		using var connection = _connectionFactory.CreateConnection();
 
-		if (_objectFlattener.ShouldFlattenType<TResult>())
+		if (_objectFlattener.TryGetTypeConverter(typeof(TResult), out var converter))
+		{
+			var simpleType = converter!.SimpleType;
+			var result = await _dapperInjection.QuerySingleAsync(connection, simpleType, query, _objectFlattener.Flatten(param), transaction, commandTimeout, commandType, cancellationToken);
+			return (TResult)converter.ConvertToComplex(result);
+		}
+		else if (_objectFlattener.ShouldFlattenType<TResult>())
 		{
 			var flatType = _objectFlattener.GetFlattenedType<TResult>();
 			var result = await _dapperInjection.QuerySingleAsync(connection, flatType, query, _objectFlattener.Flatten(param), transaction, commandTimeout, commandType, cancellationToken);

--- a/src/Dapper.DDD.Repository/Repositories/TableRepository.cs
+++ b/src/Dapper.DDD.Repository/Repositories/TableRepository.cs
@@ -6,10 +6,13 @@ where TAggregateId : notnull
 {
 	protected string TableName { get; }
 
+	protected string PropertyList { get; }
+
 	public TableRepository(IOptions<TableAggregateConfiguration<TAggregate>> options, IOptions<DefaultConfiguration> defaultOptions) : base(options.Value, defaultOptions.Value)
 	{
 		ArgumentNullException.ThrowIfNull(options.Value.TableName);
 		TableName = options.Value.TableName;
+		PropertyList = _queryGenerator.GeneratePropertyList(TableName);
 	}
 
 	#region ITableRepository

--- a/src/Dapper.DDD.Repository/Repositories/ViewRepository.cs
+++ b/src/Dapper.DDD.Repository/Repositories/ViewRepository.cs
@@ -16,10 +16,12 @@ public class ViewRepository<TAggregate> : BaseRepository<TAggregate>, IViewRepos
 where TAggregate : notnull
 {
 	protected string ViewName { get; }
+	protected string PropertyList { get; }
 
 	public ViewRepository(IOptions<ViewAggregateConfiguration<TAggregate>> options, IOptions<DefaultConfiguration> defaultOptions) : base(options.Value, defaultOptions.Value)
 	{
 		ArgumentNullException.ThrowIfNull(options.Value.ViewName);
 		ViewName = options.Value.ViewName;
+		PropertyList = _queryGenerator.GeneratePropertyList(ViewName);
 	}
 }

--- a/tests/Dapper.DDD.Repository.UnitTests/MockQueryGeneratorFactory.cs
+++ b/tests/Dapper.DDD.Repository.UnitTests/MockQueryGeneratorFactory.cs
@@ -1,0 +1,13 @@
+namespace Dapper.DDD.Repository.UnitTests;
+public class MockQueryGeneratorFactory : IQueryGeneratorFactory
+{
+	public MockQueryGeneratorFactory()
+	{
+	}
+
+	public IQueryGenerator<TAggregate> Create<TAggregate>(BaseAggregateConfiguration<TAggregate> configuration)
+	where TAggregate : notnull
+	{
+		return Mock.Of<IQueryGenerator<TAggregate>>();
+	}
+}

--- a/tests/Dapper.DDD.Repository.UnitTests/Repositories/NoDefaultsStartup.cs
+++ b/tests/Dapper.DDD.Repository.UnitTests/Repositories/NoDefaultsStartup.cs
@@ -13,7 +13,7 @@ public class NoDefaultsStartup
 		services.AddTableRepository<UserAggregate, Guid>(options =>
 		{
 			options.ConnectionFactory = Mock.Of<IConnectionFactory>();
-			options.QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>();
+			options.QueryGeneratorFactory = new MockQueryGeneratorFactory();
 			options.DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>();
 			options.TableName = "Users";
 			options.HasKey(x => x.Id);
@@ -21,7 +21,7 @@ public class NoDefaultsStartup
 		services.AddViewRepository<UserAggregate, Guid>(options =>
 		{
 			options.ConnectionFactory = Mock.Of<IConnectionFactory>();
-			options.QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>();
+			options.QueryGeneratorFactory = new MockQueryGeneratorFactory();
 			options.DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>();
 			options.ViewName = "Users";
 			options.HasKey(x => x.Id);

--- a/tests/Dapper.DDD.Repository.UnitTests/Repositories/TableRepositoryTests.cs
+++ b/tests/Dapper.DDD.Repository.UnitTests/Repositories/TableRepositoryTests.cs
@@ -30,7 +30,7 @@ public class TableRepositoryTests : IClassFixture<NoDefaultsStartup>
 			new Configuration.TableAggregateConfiguration<UserAggregate>
 			{
 				DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>(),
-				QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>()
+				QueryGeneratorFactory = new MockQueryGeneratorFactory()
 
 			}
 		), Options.Create(new Configuration.DefaultConfiguration
@@ -70,7 +70,7 @@ public class TableRepositoryTests : IClassFixture<NoDefaultsStartup>
 					new Configuration.TableAggregateConfiguration<UserAggregate>
 					{
 						ConnectionFactory = Mock.Of<IConnectionFactory>(),
-						QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>()
+						QueryGeneratorFactory = new MockQueryGeneratorFactory()
 
 					}
 				), Options.Create(new Configuration.DefaultConfiguration
@@ -88,7 +88,7 @@ public class TableRepositoryTests : IClassFixture<NoDefaultsStartup>
 		var config = new Configuration.TableAggregateConfiguration<UserAggregate>
 		{
 			ConnectionFactory = Mock.Of<IConnectionFactory>(),
-			QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>(),
+			QueryGeneratorFactory = new MockQueryGeneratorFactory(),
 			DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>(),
 			Schema = "dbo"
 		};
@@ -110,7 +110,7 @@ public class TableRepositoryTests : IClassFixture<NoDefaultsStartup>
 		var config = new Configuration.TableAggregateConfiguration<UserAggregate>
 		{
 			ConnectionFactory = Mock.Of<IConnectionFactory>(),
-			QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>(),
+			QueryGeneratorFactory = new MockQueryGeneratorFactory(),
 			DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>(),
 			TableName = "Users"
 		};
@@ -131,7 +131,7 @@ public class TableRepositoryTests : IClassFixture<NoDefaultsStartup>
 		var config = new Configuration.TableAggregateConfiguration<UserAggregate>
 		{
 			ConnectionFactory = Mock.Of<IConnectionFactory>(),
-			QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>(),
+			QueryGeneratorFactory = new MockQueryGeneratorFactory(),
 			DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>(),
 			TableName = "Users"
 		};

--- a/tests/Dapper.DDD.Repository.UnitTests/Repositories/ViewRepositoryTests.cs
+++ b/tests/Dapper.DDD.Repository.UnitTests/Repositories/ViewRepositoryTests.cs
@@ -28,7 +28,7 @@ public class ViewRepositoryTests : IClassFixture<NoDefaultsStartup>
 		var config = new Configuration.ViewAggregateConfiguration<UserAggregate>
 		{
 			DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>(),
-			QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>()
+			QueryGeneratorFactory = new MockQueryGeneratorFactory()
 		};
 		config.HasKey(x => x.Id);
 
@@ -68,7 +68,7 @@ public class ViewRepositoryTests : IClassFixture<NoDefaultsStartup>
 		var config = new Configuration.ViewAggregateConfiguration<UserAggregate>
 		{
 			ConnectionFactory = Mock.Of<IConnectionFactory>(),
-			QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>()
+			QueryGeneratorFactory = new MockQueryGeneratorFactory()
 		};
 		config.HasKey(x => x.Id);
 
@@ -88,7 +88,7 @@ public class ViewRepositoryTests : IClassFixture<NoDefaultsStartup>
 		var config = new Configuration.ViewAggregateConfiguration<UserAggregate>
 		{
 			ConnectionFactory = Mock.Of<IConnectionFactory>(),
-			QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>(),
+			QueryGeneratorFactory = new MockQueryGeneratorFactory(),
 			DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>(),
 			Schema = "dbo"
 		};
@@ -110,7 +110,7 @@ public class ViewRepositoryTests : IClassFixture<NoDefaultsStartup>
 		var config = new Configuration.ViewAggregateConfiguration<UserAggregate>
 		{
 			ConnectionFactory = Mock.Of<IConnectionFactory>(),
-			QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>(),
+			QueryGeneratorFactory = new MockQueryGeneratorFactory(),
 			DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>(),
 			ViewName = "Users"
 		};
@@ -131,7 +131,7 @@ public class ViewRepositoryTests : IClassFixture<NoDefaultsStartup>
 		var config = new Configuration.ViewAggregateConfiguration<UserAggregate>
 		{
 			ConnectionFactory = Mock.Of<IConnectionFactory>(),
-			QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>(),
+			QueryGeneratorFactory = new MockQueryGeneratorFactory(),
 			DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>(),
 			ViewName = "Users"
 		};
@@ -152,7 +152,7 @@ public class ViewRepositoryTests : IClassFixture<NoDefaultsStartup>
 		var config = new Configuration.ViewAggregateConfiguration<UserAggregate>
 		{
 			ConnectionFactory = Mock.Of<IConnectionFactory>(),
-			QueryGeneratorFactory = Mock.Of<IQueryGeneratorFactory>(),
+			QueryGeneratorFactory = new MockQueryGeneratorFactory(),
 			DapperInjectionFactory = Mock.Of<IDapperInjectionFactory>(),
 			ViewName = "Users"
 		};


### PR DESCRIPTION
- Added `PropertyList` property on both `TableRepository` and `ViewRepository` which contains all properties AND takes care of `.Serialize()` if necessary.
- Added nullability support for custom types by converting to `Nullable<TPrimtive>` for the database.
- Added support for using lists, arrays or enums of custom types (with a `TypeConverter`) as params to queries.