### PR TITLE
feat: Improved handling of Upsert when dealing with identity

### DIFF
--- a/src/Dapper.DDD.Repository.MySql/Dapper.DDD.Repository.MySql.csproj
+++ b/src/Dapper.DDD.Repository.MySql/Dapper.DDD.Repository.MySql.csproj
@@ -8,7 +8,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<Version>1.6.0</Version>
+		<Version>1.6.1</Version>
 		<Authors>Steffen Skov</Authors>
 		<Company>Steffen Skov</Company>
 		<Description>MySql and MariaDB support for the Dapper.DDD.Repository package.</Description>

--- a/src/Dapper.DDD.Repository.MySql/MySqlQueryGenerator.cs
+++ b/src/Dapper.DDD.Repository.MySql/MySqlQueryGenerator.cs
@@ -124,9 +124,11 @@ internal class MySqlQueryGenerator<TAggregate> : IQueryGenerator<TAggregate>
 	{
 		var insertQuery = GenerateInsertQuery(aggregate);
 
-		if (_identities.Any()) // Upsert makes no sense with identity, as a new Id is always generated
+		if (_identities.Any())
 		{
-			return insertQuery;
+			return _identities.Any(prop => !prop.HasDefaultValue(aggregate))
+					? GenerateUpdateQuery(aggregate) // One or more identities have a specified value => do an update 
+					: insertQuery; // All identities are default => do an insert
 		}
 		
 		var semicolonIndex = insertQuery.IndexOf(';');

--- a/src/Dapper.DDD.Repository.Sql/Dapper.DDD.Repository.Sql.csproj
+++ b/src/Dapper.DDD.Repository.Sql/Dapper.DDD.Repository.Sql.csproj
@@ -9,7 +9,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<Version>1.6.0</Version>
+		<Version>1.6.1</Version>
 		<Authors>Steffen Skov</Authors>
 		<Company>Steffen Skov</Company>
 		<Description>MS SqlServer support for the Dapper.DDD.Repository package.</Description>

--- a/src/Dapper.DDD.Repository.Sql/SqlQueryGenerator.cs
+++ b/src/Dapper.DDD.Repository.Sql/SqlQueryGenerator.cs
@@ -113,9 +113,11 @@ internal class SqlQueryGenerator<TAggregate> : IQueryGenerator<TAggregate>
 	{
 		var insertQuery = GenerateInsertQuery(aggregate);
 
-		if (_identities.Any()) // Upsert makes no sense with identity, as a new Id is always generated
+		if (_identities.Any())
 		{
-			return insertQuery;
+			return _identities.Any(prop => !prop.HasDefaultValue(aggregate)) 
+					? GenerateUpdateQuery(aggregate) // One or more identities have a specified value => do an update 
+					: insertQuery; // All identities are default => do an insert
 		}
 
 		var whereClause = GenerateWhereClause();

--- a/tests/Dapper.DDD.Repository.UnitTests/MySql/MySqlQueryGeneratorTests.cs
+++ b/tests/Dapper.DDD.Repository.UnitTests/MySql/MySqlQueryGeneratorTests.cs
@@ -547,6 +547,20 @@ public class QueryGeneratorTests
 	}
 
 	[Fact]
+	public void GenerateUpsertQuery_HasIdentityWithExistingValue_ReturnsPureUpdateQuery()
+	{
+		// Arrange
+		var generator = CreateSinglePrimaryKeyAggregateQueryGenerator();
+
+		// Act
+		var query = generator.GenerateUpsertQuery(new SinglePrimaryKeyAggregate{ Id = 42 });
+		var updateQuery = generator.GenerateUpdateQuery(new SinglePrimaryKeyAggregate());
+
+		// Assert
+		Assert.Equal(updateQuery, query);
+	}
+
+	[Fact]
 	public void GenerateUpsertQuery_HasNoIdentity_Valid()
 	{
 		// Arrange

--- a/tests/Dapper.DDD.Repository.UnitTests/Sql/SqlQueryGeneratorTests.cs
+++ b/tests/Dapper.DDD.Repository.UnitTests/Sql/SqlQueryGeneratorTests.cs
@@ -716,6 +716,20 @@ public class QueryGeneratorTests
 		// Assert
 		Assert.Equal(insertQuery, query);
 	}
+
+	[Fact]
+	public void GenerateUpsertQuery_HasIdentityWithExistingValue_ReturnsPureUpdateQuery()
+	{
+		// Arrange
+		var generator = CreateSinglePrimaryKeyAggregateQueryGenerator();
+
+		// Act
+		var query = generator.GenerateUpsertQuery(new SinglePrimaryKeyAggregate { Id = 42 });
+		var updateQuery = generator.GenerateUpdateQuery(new SinglePrimaryKeyAggregate());
+
+		// Assert
+		Assert.Equal(updateQuery, query);
+	}
 	
 	[Fact]
 	public void GenerateUpsertQuery_HasNoIdentity_Valid()


### PR DESCRIPTION
For Aggregates with a configured Identity property, Upsert will now behave like this:

If the Identity property has a non-default value => Update
Else => Insert